### PR TITLE
Fixed database loading bug

### DIFF
--- a/lib/string_to_arpa.rb
+++ b/lib/string_to_arpa.rb
@@ -2,7 +2,7 @@ require "string_to_arpa/version"
 require "sqlite3"
 
 module StringToArpa
-  DATABASE = SQLite3::Database.new("arpagem.db")
+  DATABASE = SQLite3::Database.new(File.join(File.expand_path(File.dirname(__FILE__)), "..", "arpagem.db")
 
   DATABASE.results_as_hash = true
   DATABASE.execute( "PRAGMA encoding = \"UTF-16\"" );


### PR DESCRIPTION
Fixed the bug that prevents the database from being loaded because it is actually in the root directory and not next to `lib/string_to_arpa.rb`.  This could also be fixed by moving `arpagem.db` to `lib/` but this way makes more sense to me.